### PR TITLE
Pictures and Titles in community

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -427,7 +427,7 @@
   color: #114848;
   text-transform: uppercase;
   font-weight: 700;
-  font-size: 22px;
+  font-size: 24px;
   line-height: 1.5em;
   height: 3em;
   overflow: hidden;


### PR DESCRIPTION
Pictures appear normal size throughout. Titles are set to two lines.
